### PR TITLE
Enable goreleaser in the repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,34 @@ jobs:
           key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
           paths:
             - ~/.cache/pre-commit
+  release:
+    docker:
+      - image: *circleci-docker-primary
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Run goreleaser
+          command: goreleaser --debug
+      - run:
+          name: Login to Docker Hub
+          command: docker login -u $DOCKER_USER -p $DOCKER_PASS
+      - run:
+          name: Check Docker container
+          command: docker run -it trussworks/find-guardduty-user:<< pipeline.git.tag >> --help
+      - run:
+          name: Docker push
+          command: docker push trussworks/find-guardduty-user:<< pipeline.git.tag >>
 workflows:
   version: 2.1
   validate:
     jobs:
       - validate
+  release:
+    jobs:
+      - release:
+          filters:
+            branches:
+              ignore: /^.*/
+            tags:
+              only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,20 +24,17 @@ jobs:
       - image: *circleci-docker-primary
     steps:
       - checkout
-      # - setup_remote_docker
+      - setup_remote_docker
+      - run: goreleaser
       - run:
-          name: Run goreleaser
-          command: goreleaser --debug
-      # - run: curl -sL https://git.io/goreleaser | bash
-      # - run:
-      #     name: Login to Docker Hub
-      #     command: docker login -u $DOCKER_USER -p $DOCKER_PASS
-      # - run:
-      #     name: Check Docker container
-      #     command: docker run -it trussworks/find-guardduty-user:<< pipeline.git.tag >> --help
-      # - run:
-      #     name: Docker push
-      #     command: docker push trussworks/find-guardduty-user:<< pipeline.git.tag >>
+          name: Login to Docker Hub
+          command: docker login -u $DOCKER_USER -p $DOCKER_PASS
+      - run:
+          name: Test that Docker container works
+          command: docker run -it trussworks/find-guardduty-user:<< pipeline.git.tag >> help
+      - run:
+          name: Docker push
+          command: docker push trussworks/find-guardduty-user:<< pipeline.git.tag >>
 workflows:
   version: 2.1
   validate:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,19 +24,20 @@ jobs:
       - image: *circleci-docker-primary
     steps:
       - checkout
-      - setup_remote_docker
+      # - setup_remote_docker
       - run:
           name: Run goreleaser
           command: goreleaser --debug
-      - run:
-          name: Login to Docker Hub
-          command: docker login -u $DOCKER_USER -p $DOCKER_PASS
-      - run:
-          name: Check Docker container
-          command: docker run -it trussworks/find-guardduty-user:<< pipeline.git.tag >> --help
-      - run:
-          name: Docker push
-          command: docker push trussworks/find-guardduty-user:<< pipeline.git.tag >>
+      # - run: curl -sL https://git.io/goreleaser | bash
+      # - run:
+      #     name: Login to Docker Hub
+      #     command: docker login -u $DOCKER_USER -p $DOCKER_PASS
+      # - run:
+      #     name: Check Docker container
+      #     command: docker run -it trussworks/find-guardduty-user:<< pipeline.git.tag >> --help
+      # - run:
+      #     name: Docker push
+      #     command: docker push trussworks/find-guardduty-user:<< pipeline.git.tag >>
 workflows:
   version: 2.1
   validate:
@@ -49,4 +50,4 @@ workflows:
             branches:
               ignore: /^.*/
             tags:
-              only: /^v.*/
+              only: /^v[0-9]+(\.[0-9]+)*(-.*)*/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-dist
 bin/
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,14 +29,14 @@ dockers:
       - "trussworks/find-guardduty-user:{{ .Tag }}"
     skip_push: true
 archives:
-- replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
+  -
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      amd64: x86_64
 checksum:
   name_template: 'checksums.txt'
+  algorithm: sha256
 snapshot:
   name_template: "{{ .Tag }}-next"
 changelog:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,7 +27,6 @@ dockers:
       - find-guardduty-user
     image_templates:
       - "trussworks/find-guardduty-user:{{ .Tag }}"
-    skip_push: true
 archives:
   -
     replacements:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,47 @@
+env:
+  - GO111MODULE=on
+before:
+  hooks:
+    - go mod download
+builds:
+- env:
+    - CGO_ENABLED=0
+  goos:
+    - darwin
+    - linux
+  goarch:
+    - amd64
+  main: main.go
+brews:
+  - description: "find-guardduty-user is used to search CloudTrial to find users that triggered GuardDuty alerts."
+    github:
+      owner: trussworks
+      name: homebrew-tap
+    homepage: "https://github.com/trussworks/find-guardduty-user"
+    commit_author:
+      name: trussworks-infra
+      email: infra+github@truss.works
+dockers:
+  -
+    binaries:
+      - find-guardduty-user
+    image_templates:
+      - "trussworks/find-guardduty-user:{{ .Tag }}"
+    skip_push: true
+archives:
+- replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,7 @@ dockers:
       - find-guardduty-user
     image_templates:
       - "trussworks/find-guardduty-user:{{ .Tag }}"
+    skip_push: true
 archives:
   -
     replacements:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,12 @@ repos:
     rev: v0.23.1
     hooks:
       - id: markdownlint
+
+  - repo: local
+    hooks:
+      - id: goreleaser-check
+        name: Validate goreleaser config  yaml
+        entry: goreleaser check
+        language: system
+        files: '.goreleaser.yml'
+        pass_filenames: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM alpine:3
-COPY bin/find-guardduty-user /bin/find-guardduty-user
+COPY find-guardduty-user /bin/find-guardduty-user
 ENTRYPOINT [ "find-guardduty-user" ]

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,14 @@ clean: ## Clean all generated files
 	rm -rf ./bin
 	rm -rf ./dist
 
+.PHONY: goreleaser_check
+goreleaser_check: ## Goreleaser check configuration
+	goreleaser check
+
+.PHONY: goreleaser_build
+goreleaser_build: ## Goreleaser build configuration
+	goreleaser build --snapshot --rm-dist
+
 .PHONY: goreleaser_test
 goreleaser_test: ## Goreleaser test configuration
 	goreleaser --snapshot --skip-publish --rm-dist

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-VERSION = v0.0.1
+# goreleaser removes the `v` prefix when building and this does too
+VERSION = 0.0.1
 
 ifdef CIRCLECI
 	UNAME_S := $(shell uname -s)

--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,10 @@ bin/find-guardduty-user: ## Build find-guardduty-user
 .PHONY: clean
 clean: ## Clean all generated files
 	rm -rf ./bin
+	rm -rf ./dist
+
+.PHONY: goreleaser_test
+goreleaser_test: ## Goreleaser test configuration
+	goreleaser --snapshot --skip-publish --rm-dist
 
 default: help


### PR DESCRIPTION
This sets up goreleaser for this repo to deploy to docker and as a package for homebrew.  Try this out:

```sh
make goreleaser_test
docker run -it trussworks/find-guardduty-user:v0.0.0 version
```

You will see output like this:

```text
v0.0.0-next
```

Similarly you can try one of the build artifacts for distribution:

```sh
./dist/find-guardduty-user_darwin_amd64/find-guardduty-user help
```