### PR TITLE
Add a 'version' subcommand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ help:  ## Print the help documentation
 	@grep -E '^[/a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 bin/find-guardduty-user: ## Build find-guardduty-user
-	go build -ldflags "$(LDFLAGS) -X main.Version=${VERSION}" -o bin/find-guardduty-user .
+	go build -ldflags "$(LDFLAGS) -X main.version=${VERSION}" -o bin/find-guardduty-user .
 
 .PHONY: clean
 clean: ## Clean all generated files

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+VERSION = v0.0.1
+
 ifdef CIRCLECI
 	UNAME_S := $(shell uname -s)
 	ifeq ($(UNAME_S),Linux)
@@ -10,7 +12,7 @@ help:  ## Print the help documentation
 	@grep -E '^[/a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 bin/find-guardduty-user: ## Build find-guardduty-user
-	go build -ldflags "$(LDFLAGS)" -o bin/find-guardduty-user .
+	go build -ldflags "$(LDFLAGS) -X main.Version=${VERSION}" -o bin/find-guardduty-user .
 
 .PHONY: clean
 clean: ## Clean all generated files

--- a/main.go
+++ b/main.go
@@ -91,8 +91,8 @@ func (e *errInvalidOutput) Error() string {
 	return fmt.Sprintf("invalid output %s", e.Output)
 }
 
-// Version is the published version of the utility
-var Version string
+// version is the published version of the utility
+var version string
 
 const (
 	// AWSGuardDutyRegionFlag is the AWS GuardDuty Region Flag
@@ -266,11 +266,11 @@ func main() {
 }
 
 func findGuardDutyVersionFunction(cmd *cobra.Command, args []string) error {
-	if len(Version) == 0 {
+	if len(version) == 0 {
 		fmt.Println("development")
 		return nil
 	}
-	fmt.Println(Version)
+	fmt.Println(version)
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -91,6 +91,9 @@ func (e *errInvalidOutput) Error() string {
 	return fmt.Sprintf("invalid output %s", e.Output)
 }
 
+// Version is the published version of the utility
+var Version string
+
 const (
 	// AWSGuardDutyRegionFlag is the AWS GuardDuty Region Flag
 	AWSGuardDutyRegionFlag = "aws-guardduty-region"
@@ -248,9 +251,27 @@ func main() {
 	initFlags(findGuardDutyUserCommand.Flags())
 	root.AddCommand(findGuardDutyUserCommand)
 
+	findGuardDutyVersionCommand := &cobra.Command{
+		Use:                   "version",
+		DisableFlagsInUseLine: true,
+		Short:                 "Print the version",
+		Long:                  "Print the version",
+		RunE:                  findGuardDutyVersionFunction,
+	}
+	root.AddCommand(findGuardDutyVersionCommand)
+
 	if err := root.Execute(); err != nil {
 		panic(err)
 	}
+}
+
+func findGuardDutyVersionFunction(cmd *cobra.Command, args []string) error {
+	if len(Version) == 0 {
+		fmt.Println("development")
+		return nil
+	}
+	fmt.Println(Version)
+	return nil
 }
 
 func findGuardDutyUserFunction(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Utilities should have a version sub-command. This adds a minimal one that has to be managed for each release during the binary build. It's not part of the code, meaning if its not passed in as an LDFLAG it will default to saying `development` as the version.

Try this out:

```sh
go run . version
```

The output should be `development`. Try it out by building:

```sh
make bin/find-guardduty-user
./bin/find-guardduty-user version
```

The output should be `v0.0.1`. This means we can modify the version as part of the `Makefile` or CircleCI pipeline, giving us some flexibility.