### PR TITLE
Use truss pre-commit hook for goreleaser and circleci validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,13 +7,8 @@ repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
     rev: v3.1.0
     hooks:
-      - id: check-json
       - id: check-merge-conflict
       - id: check-yaml
-      - id: detect-private-key
-      - id: pretty-format-json
-        args:
-          - --autofix
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,11 +21,8 @@ repos:
     hooks:
       - id: markdownlint
 
-  - repo: local
+  - repo: git://github.com/trussworks/pre-commit-hooks
+    rev: v0.0.4
     hooks:
+      - id: circleci-validate
       - id: goreleaser-check
-        name: Validate goreleaser config  yaml
-        entry: goreleaser check
-        language: system
-        files: '.goreleaser.yml'
-        pass_filenames: false


### PR DESCRIPTION
This sets this repo up with the Truss pre-commit hooks. Also remove some useless hooks.