### PR TITLE
Adding partition flag to find-guardduty-user

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ Usage:
   find-guardduty-user find [flags]
 
 Flags:
-      --aws-guardduty-region string   AWS region used inspecting guardduty (default "us-west-2")
+  -p    --aws-guardduty-partition string AWS partition ('aws' or 'aws-us-gov') used for inspecting guardduty (default "aws")
+  -r    --aws-guardduty-region string   AWS region used for inspecting guardduty (default "us-west-2")
   -a, --archived                      Show archived findings instead of current findings
-  -o, --output string                 Whether to print output as 'text' or 'json' (default "json")
+  -o, --output string                 Whether to print output as 'text' or 'json' (default "text")
   -v, --debug-logging                 log messages at the debug level.
   -h, --help                          help for find
 ```
@@ -44,14 +45,20 @@ Run the command like this:
 find-guardduty-user find
 ```
 
+Run the command in GovCloud like this:
+
+```sh
+find-guardduty-user find -p aws-us-gov -r us-gov-west-1
+```
+
 Review archived findings:
 
 ```sh
 find-guardduty-user find -a
 ```
 
-Look at the output in a TEXT format for easy reading:
+Look at the output in JSON format:
 
 ```sh
-find-guardduty-user find -o text
+find-guardduty-user find -o json
 ```

--- a/main.go
+++ b/main.go
@@ -75,6 +75,14 @@ City, Country:      %s, %s`
 	))
 }
 
+type errInvalidPartition struct {
+	Partition string
+}
+
+func (e *errInvalidPartition) Error() string {
+	return fmt.Sprintf("invalid partition %s", e.Partition)
+}
+
 type errInvalidRegion struct {
 	Region string
 }
@@ -122,9 +130,14 @@ func initFlags(flag *pflag.FlagSet) {
 
 func checkRegion(v *viper.Viper) error {
 
-	regions, ok := endpoints.RegionsForService(endpoints.DefaultPartitions(), endpoints.AwsPartitionID, endpoints.GuarddutyServiceID)
+	regions, ok := endpoints.RegionsForService(endpoints.DefaultPartitions(), v.GetString(AWSGuardDutyPartitionFlag), endpoints.GuarddutyServiceID)
 	if !ok {
 		return fmt.Errorf("could not find regions for service %s", endpoints.GuarddutyServiceID)
+	}
+
+	p := v.GetString(AWSGuardDutyPartitionFlag)
+	if len(p) == 0 {
+		return fmt.Errorf("%s is invalid: %w", AWSGuardDutyPartitionFlag, &errInvalidPartition{Partition: p})
 	}
 
 	r := v.GetString(AWSGuardDutyRegionFlag)

--- a/main.go
+++ b/main.go
@@ -117,10 +117,10 @@ const (
 
 func initFlags(flag *pflag.FlagSet) {
 
-	flag.StringP(AWSGuardDutyPartitionFlag, "p", "aws", "AWS partition used for inspecting guardduty")
+	flag.StringP(AWSGuardDutyPartitionFlag, "p", "aws", "AWS partition ('aws' or 'aws-us-gov') used for inspecting guardduty")
 	flag.StringP(AWSGuardDutyRegionFlag, "r", "us-west-2", "AWS region used for inspecting guardduty")
 	flag.BoolP(ArchivedFlag, "a", false, "Show archived findings instead of current findings")
-	flag.StringP(OutputFlag, "o", "json", "Whether to print output as 'text' or 'json'")
+	flag.StringP(OutputFlag, "o", "text", "Whether to print output as 'text' or 'json'")
 
 	// Verbose
 	flag.BoolP(VerboseFlag, "v", false, "log messages at the debug level.")

--- a/main.go
+++ b/main.go
@@ -95,6 +95,8 @@ func (e *errInvalidOutput) Error() string {
 var version string
 
 const (
+	// AWSGuardDutyPartitionFlag is the AWS Guard Duty Partition Flag
+	AWSGuardDutyPartitionFlag = "aws-guardduty-partition"
 	// AWSGuardDutyRegionFlag is the AWS GuardDuty Region Flag
 	AWSGuardDutyRegionFlag = "aws-guardduty-region"
 	// ArchivedFlag is the Archive Flag
@@ -107,7 +109,8 @@ const (
 
 func initFlags(flag *pflag.FlagSet) {
 
-	flag.String(AWSGuardDutyRegionFlag, endpoints.UsWest2RegionID, "AWS region used inspecting guardduty")
+	flag.StringP(AWSGuardDutyPartitionFlag, "p", "aws", "AWS partition used for inspecting guardduty")
+	flag.StringP(AWSGuardDutyRegionFlag, "r", "us-west-2", "AWS region used for inspecting guardduty")
 	flag.BoolP(ArchivedFlag, "a", false, "Show archived findings instead of current findings")
 	flag.StringP(OutputFlag, "o", "json", "Whether to print output as 'text' or 'json'")
 


### PR DESCRIPTION
Added a Partition flag allowing this to be used in both AWS Commercial and AWS GovCloud. Set default output to text rather than json. Updated the README. 
