### PR TITLE
bump go to 1.16

### DIFF
--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -20,7 +20,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v1
         with:
-          go-version: "1.14"
+          go-version: "1.16"
       - name: Tidy
         run: |
           go version

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/trussworks/find-guardduty-user
 
-go 1.14
+go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.38.64

--- a/go.sum
+++ b/go.sum
@@ -245,7 +245,6 @@ golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=


### PR DESCRIPTION
https://github.com/trussworks/find-guardduty-user/pull/59 failed with the following error during `go mod tiny`:

```
github.com/trussworks/find-guardduty-user imports
	github.com/spf13/viper imports
	github.com/spf13/afero imports
	io/fs: package io/fs is not in GOROOT (/opt/hostedtoolcache/go/1.14.15/x64/src/io/fs)
github.com/trussworks/find-guardduty-user imports
	github.com/spf13/viper imports
	github.com/spf13/afero tested by
	github.com/spf13/afero.test imports
	testing/fstest: package testing/fstest is not in GOROOT (/opt/hostedtoolcache/go/1.14.15/x64/src/testing/fstest)
Error: Process completed with exit code 1.
```

`io/fs` and `testing/fstest` are new packages in Go 1.16 (https://golang.org/doc/go1.16#fs). In order to keep dependencies up to date that have migrated to Go 1.16, we need to upgrade to 1.16 as well.